### PR TITLE
avoid rebuild of the R package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
  * [Drat](https://github.com/eddelbuettel/drat) is a useful little package, for, *inter-alia*, using
 github *gh-pages* as an R repository
- * [Travis](https://github.com/craigcitro/r-travis) is a hosted continuous integration service. 
+ * [Travis](https://github.com/craigcitro/r-travis) is a hosted continuous integration service.
  It is integrated with gitHub and offers first class support for a number of languages, but importantly, R.
- 
+
 This package illustrates how to automatically update a `drat` github repository, on a *successful* travis build.
 
 ## Getting Started
@@ -40,7 +40,7 @@ give you a chance to copy it down.
   after_success:
     - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
   ```
-  
+
     to your `.travis.yml` file. This means your `drat` repository is only updated:
     - for successful builds
     - only on the master branch
@@ -49,5 +49,4 @@ give you a chance to copy it down.
 ## TODO
 
 1. The bash script is a bit hacky.
-1. I suspect the call to `devtools::build` in `deploy.sh` isn't needed. Since travis has already built the R package, it should be around somewhere (but I couldn't find it).
 1. It should be possible to only update if a version is tagged. Travis provides a variable `$TRAVIS_TAG`, that is empty if the commit isn't a tag. **But** when tagging, `$TRAVIS_BRANCH` also changes to the tag name.

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,8 @@
 set -o errexit -o nounset
 
 addToDrat(){
+  PKG_REPO=$PWD
+
   cd ..; mkdir drat; cd drat
 
   ## Set up Repo parameters
@@ -16,7 +18,7 @@ addToDrat(){
   git fetch upstream
   git checkout gh-pages
 
-  Rscript -e "drat::insertPackage(devtools::build('../dratTravis'), \
+  Rscript -e "drat::insertPackage('$PKG_REPO/$PKG_TARBALL', \
     repodir = '.', \
     commit='Travis update: build $TRAVIS_BUILD_NUMBER')"
   git push


### PR DESCRIPTION
Dear Colin,

thanks for investigating the deployment with travis and `drat`.

This PR removes the additional build process from the `deploy.sh` script.

Best wishes,

Sebastian

P.S.: I also created a PR against `drat` https://github.com/eddelbuettel/drat/pull/24.
